### PR TITLE
Urllib version downgrade for compatibility with Accounts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ wheel==0.36.2
 python-dateutil >= 1.5
 pytest==6.2.2
 pycodestyle==2.6.0
-urllib3==1.26.2
+urllib3==1.24.3
 beautifulsoup4==4.9.3
 bs4==0.0.1 


### PR DESCRIPTION
Downgrade to 1.24.3 in order to ensure compatibility with django-oauth-toolkit used by Accounts.