### PR TITLE
TESTS: Fixed failing tests for LU rates, added GHA workflow to prevent GHAs disability after 60 days

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,3 +57,13 @@ jobs:
           curl -X POST -H 'Content-Type: application/json' \
             -d '{"text": "'"$MSG"'", "username": "GHA", "channel": "#mergado_cicd", "icon_emoji": ":mergadodevsbot:"}' \
             ${{ secrets.ROCKETCHAT_WEBHOOK }}
+  keepalive:
+    name: Create dummy commit
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v2
+      - name: Keepalive Workflow
+        uses: gautamkrishnar/keepalive-workflow@master
+        with:
+          time_elapsed: 40

--- a/tests/test_rates.py
+++ b/tests/test_rates.py
@@ -9,6 +9,10 @@ def test_rates():
     rates = RateManager()
     try:
         for ms in tic.msa_map:
+            # E-Services standard tax rate for LU is not provided by vrws
+            # since 10-01-2022
+            if ms == 'LU':
+                continue
             rate = rates._get_rates(ms)
             categories = rates.categories(ms)
             eservices_rate1 = rates.category_rate(
@@ -32,6 +36,10 @@ def test_rates_vrws_tic():
     rates = RateManager()
     for ms in tic.msa_map:
         try:
+            # E-Services standard tax rate for LU is not provided by vrws
+            # since 10-01-2022
+            if ms == 'LU':
+                continue
             vrws_standard = vrws.get_rates(ms, typeVR=vrws.STANDARD)
             vrws_standard_rate = vrws_standard.categories.get(vrws.ESERVICES)[0].rate
             tic_standard = tic.get_rates(ms, typeVR=vrws.STANDARD)


### PR DESCRIPTION
### Includes:
- Luxembourg rates check skipped in tests
- separate test created for LU to detect standard rate is provided again
- new job created to run next to tests twice a month to create dummy commit in case repository is inactive for over 40 days (to prevent GHAs disability by GH)

Using GHA [keepalive-workflow](https://github.com/gautamkrishnar/keepalive-workflow/blob/master/README.md)